### PR TITLE
feat: Centralize base URI configuration .replaced hardcoded data or functionnwith config reader 

### DIFF
--- a/src/test/java/com/Mock/BaseTest.java
+++ b/src/test/java/com/Mock/BaseTest.java
@@ -1,6 +1,7 @@
 package com.Mock;
 
 
+import com.config.ConfigReader;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -12,10 +13,10 @@ public class BaseTest {
     @BeforeSuite
     public void setup()
     {
-        RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri("https://de0a4e67-8fb6-421b-883c-caaa920b6525.mock.pstmn.io")
+        RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri(ConfigReader.getMockBaseURI())
                 .setContentType(ContentType.JSON).addHeader("x-api-key","PMAK-6654b1baeeb31b0001abfda6-7ce922b6aa65f23e202cc4fde6f2d8d955").build();
 
-        /*RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri("https://api.realworld.io/api/")
+        /*RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri(ConfigReader.getConduitBaseURI())
                 .setContentType(ContentType.JSON).addFilter(new ResponseLoggingFilter()).addFilter(new RequestLoggingFilter()).build();*/
 
         RestAssured.requestSpecification =requestSpecification;

--- a/src/test/java/com/conduit/request/ApiTestBase.java
+++ b/src/test/java/com/conduit/request/ApiTestBase.java
@@ -1,6 +1,7 @@
 package com.conduit.request;
 
 import br.com.six2six.fixturefactory.loader.FixtureFactoryLoader;
+import com.config.ConfigReader;
 import com.conduit.request.ApiTest.articleAPITest;
 import com.conduit.util.tokenUtil;
 import io.restassured.RestAssured;
@@ -83,7 +84,7 @@ public class ApiTestBase {
 
     private static RequestSpecification createRequestSpecification(PrintStream logFile) {
         return new RequestSpecBuilder()
-                .setBaseUri("https://api.realworld.io/api/")
+                .setBaseUri(ConfigReader.getConduitBaseURI())
                 .setContentType(ContentType.JSON)
                 .addFilter(new RequestLoggingFilter(logFile))    // Logs to file
                 .addFilter(new ResponseLoggingFilter(logFile))   // Logs to file
@@ -94,7 +95,7 @@ public class ApiTestBase {
 
     private static RequestSpecification createRequestSpecification(PrintStream logFile, String bearerToken, String authToken) {
         return new RequestSpecBuilder()
-                .setBaseUri("https://api.realworld.io/api/")
+                .setBaseUri(ConfigReader.getConduitBaseURI())
                 .setContentType(ContentType.JSON)
                 .addHeader("Authorization", String.valueOf(bearerToken)).addHeader("authorization","Token " + authToken)  // Apply bearer token to all requests
                 .addFilter(new RequestLoggingFilter(logFile))    // Logs to file

--- a/src/test/java/com/conduit/request/BaseTest.java
+++ b/src/test/java/com/conduit/request/BaseTest.java
@@ -1,6 +1,7 @@
 package com.conduit.request;
 
 
+import com.config.ConfigReader;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.RequestLoggingFilter;
@@ -15,10 +16,10 @@ public class BaseTest {
     @BeforeSuite
     public void setup()
     {
-        RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri("https://api.realworld.io/api/")
+        RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri(ConfigReader.getConduitBaseURI())
                 .setContentType(ContentType.JSON).build();
 
-        /*RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri("https://api.realworld.io/api/")
+        /*RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri(ConfigReader.getConduitBaseURI())
                 .setContentType(ContentType.JSON).addFilter(new ResponseLoggingFilter()).addFilter(new RequestLoggingFilter()).build();*/
 
         RestAssured.requestSpecification =requestSpecification;

--- a/src/test/java/com/config/ConfigReader.java
+++ b/src/test/java/com/config/ConfigReader.java
@@ -1,0 +1,41 @@
+package com.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class ConfigReader {
+
+    private static final Properties properties = new Properties();
+    private static final String CONFIG_FILE_NAME = "config.properties";
+
+    static {
+        try (InputStream input = ConfigReader.class.getClassLoader().getResourceAsStream(CONFIG_FILE_NAME)) {
+            if (input == null) {
+                System.out.println("Sorry, unable to find " + CONFIG_FILE_NAME);
+                // Consider throwing an exception here if the config file is critical
+            } else {
+                properties.load(input);
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            // Consider throwing a runtime exception here
+        }
+    }
+
+    public static String getProperty(String propertyName) {
+        return properties.getProperty(propertyName);
+    }
+
+    public static String getMockBaseURI() {
+        return properties.getProperty("mock.baseURI");
+    }
+
+    public static String getConduitBaseURI() {
+        return properties.getProperty("conduit.baseURI");
+    }
+
+    public static String getHVBaseURI() {
+        return properties.getProperty("hv.baseURI");
+    }
+}

--- a/src/test/java/com/config/ConfigReaderTest.java
+++ b/src/test/java/com/config/ConfigReaderTest.java
@@ -1,0 +1,41 @@
+package com.config;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ConfigReaderTest {
+
+    @Test
+    public void testGetMockBaseURI() {
+        String expectedUri = "https://de0a4e67-8fb6-421b-883c-caaa920b6525.mock.pstmn.io";
+        String actualUri = ConfigReader.getMockBaseURI();
+        Assert.assertEquals(actualUri, expectedUri, "Mock Base URI should match the value in config.properties");
+    }
+
+    @Test
+    public void testGetConduitBaseURI() {
+        String expectedUri = "https://api.realworld.io/api/";
+        String actualUri = ConfigReader.getConduitBaseURI();
+        Assert.assertEquals(actualUri, expectedUri, "Conduit Base URI should match the value in config.properties");
+    }
+
+    @Test
+    public void testGetHVBaseURI() {
+        String expectedUri = "http://localhost:3004";
+        String actualUri = ConfigReader.getHVBaseURI();
+        Assert.assertEquals(actualUri, expectedUri, "HV Base URI should match the value in config.properties");
+    }
+
+    @Test
+    public void testGetProperty_existingProperty() {
+        String expectedUri = "https://api.realworld.io/api/"; // conduit.baseURI
+        String actualUri = ConfigReader.getProperty("conduit.baseURI");
+        Assert.assertEquals(actualUri, expectedUri, "getProperty should return the correct value for an existing property.");
+    }
+
+    @Test
+    public void testGetProperty_nonExistingProperty() {
+        String actualUri = ConfigReader.getProperty("non.existent.property");
+        Assert.assertNull(actualUri, "getProperty should return null for a non-existing property.");
+    }
+}

--- a/src/test/java/com/hv/request/BaseTest.java
+++ b/src/test/java/com/hv/request/BaseTest.java
@@ -1,5 +1,6 @@
 package com.hv.request;
 
+import com.config.ConfigReader;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
@@ -18,7 +19,7 @@ public class BaseTest {
 @BeforeClass
 public void setup()
 {
-    RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri("http://localhost:3004")
+    RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri(ConfigReader.getHVBaseURI())
             .setContentType(ContentType.JSON).
            addFilter( new RequestLoggingFilter())
             .addFilter(new ResponseLoggingFilter()).build();

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -1,0 +1,3 @@
+mock.baseURI=https://de0a4e67-8fb6-421b-883c-caaa920b6525.mock.pstmn.io
+conduit.baseURI=https://api.realworld.io/api/
+hv.baseURI=http://localhost:3004


### PR DESCRIPTION
Introduces a `config.properties` file and a `ConfigReader` utility class to manage base URIs for different test environments.

Modified `BaseTest` and `ApiTestBase` classes to use the `ConfigReader` for setting base URIs, removing hardcoded values.

Added `ConfigReaderTest` to ensure the utility class functions as expected.

This change allows for easier management and modification of base URIs without altering test class code directly.